### PR TITLE
Brew steps for antibody, mysql5.7, dotfile support for mysql

### DIFF
--- a/Brewfile.osx
+++ b/Brewfile.osx
@@ -5,6 +5,12 @@ brew "python"
 # https://aws.amazon.com/cli/
 brew "awscli@1"
 
+# antibody, zsh plugin manager
+brew "antibody"
+
+# mysql 5.7
+brew "mysql@5.7"
+
 # CLI for managing secrets
 # https://github.com/segmentio/chamber
 brew "chamber"

--- a/dotfiles/.zsh/.zshrc
+++ b/dotfiles/.zsh/.zshrc
@@ -34,3 +34,6 @@ source /usr/local/share/autojump/autojump.zsh 2>/dev/null
 # load machine specific configuration
 #
 [ -f "$0.local" ] && source "$0.local"
+
+# use the mysql install from brew
+export PATH="/usr/local/opt/mysql-client/bin:$PATH"


### PR DESCRIPTION
added antibody back, i removed it initially because I imagined folks like to setup their own ZSH and antibody isn't even the standard for plugin management but their's a large amount of plugins already configured in the dotfiles with it. I also added mysql through brew because they support a cask for 5.7, and i initially didn't realize that we all share a base .zshrc so you won't have to manually add the mysql line for repos that are built around mysql

## What and Why
theres a zshrc we all share that has a couple plugins that needs antibody so this adds that back into the brew step. This also adds a cask for mysql@5.7 so it can skip a step that most repo's need to add manually

## Humor for Reviewer