### PR TITLE
Feature/un 6449 fix old pos references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ bootstrap: init .vars
 	-make brew
 	sudo python -m ensurepip --upgrade
 	pip3 install virtualenv
+	git lfs install
 	make dotfiles
 .PHONY: bootstrap
 


### PR DESCRIPTION
## What and Why
git lfs needs an extra step to work. right now without it and running devsandbox you have to delete and clone pos again.

devsandbox changes are [here](https://github.com/UnionPOS/DevSandbox/pull/138)

## Related Tickets and PRs

Fixes [UN-6449](https://tabbedout.atlassian.net/browse/UN-6449)

## Steps to Test
install baseline
install devsandbox
compile POS
observe that simulator launches without issue

## Humor for Reviewer